### PR TITLE
Tasks: check if services are enabled before removing them

### DIFF
--- a/tasks/disable_other_ntp_services.yml
+++ b/tasks/disable_other_ntp_services.yml
@@ -3,7 +3,7 @@
   ansible.builtin.service_facts:
   register: services_state
 
-- when: __ntpd_service_name ~ '.service' in ansible_facts.services
+- when: ansible_facts.services["__ntpd_service_name ~ '.service'"] is defined and ansible_facts.services["__ntpd_service_name ~ '.service'"].status == 'enabled'
   block:
     - name: stop ntpd service
       ansible.builtin.service:
@@ -16,7 +16,7 @@
         name: "{{ __ntpd_package_name }}"
         state: absent
 
-- when: __openntpd_service_name ~ '.service' in ansible_facts.services
+- when: ansible_facts.services["__openntpd_service_name ~ '.service'"] is defined and ansible_facts.services["__openntpd_service_name ~ '.service'"].status == 'enabled'
   block:
     - name: stop openntpd service
       ansible.builtin.service:
@@ -34,4 +34,4 @@
     name: systemd-timesyncd
     enabled: false
     state: stopped
-  when: __timesyncd_service_name ~ '.service' in ansible_facts.services
+  when: ansible_facts.services["__timesyncd_service_name ~ '.service'"] is defined and ansible_facts.services["__timesyncd_service_name ~ '.service'"].status == 'enabled'


### PR DESCRIPTION
Hi,
i figured out when using this role on a fresh Debian Bullseye, that service facts were defined, but the status itself claimed: `"status": "not-found"` which leads to the role failing:

```yaml
            "ntp.service": {
                "name": "ntp.service",
                "source": "systemd",
                "state": "stopped",
                "status": "not-found"

```
Now the role checks if the services in doubt are enabled before trying to remove then.